### PR TITLE
fix: build error when used with use_frameworks!

### DIFF
--- a/react-native-override-color-scheme.podspec
+++ b/react-native-override-color-scheme.podspec
@@ -15,5 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
+  s.static_framework = true
+
   s.dependency "React-Core"
 end


### PR DESCRIPTION
This PR adds support for static frameworks. I have tested, and it's working with projects using `use_frameworks!` in their Podfile. We need to check if it works for projects not using `use_frameworks!`.

@Polarisation could you please help me with the tests? :)