### PR TITLE
chore: update minSdkVersion to 24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:7.4.2'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
@@ -22,15 +22,15 @@ def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['OverrideColorScheme_' + name]
 }
 
-def getExtOrIntegerDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['OverrideColorScheme_' + name]).toInteger()
+def getExtOrIntegerDefault(name, fallback) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.hasProperty('OverrideColorScheme_' + name) ? project.properties['OverrideColorScheme_' + name].toInteger() : fallback)
 }
 
 android {
-  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
+  compileSdkVersion getExtOrIntegerDefault('compileSdkVersion', 34)
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+    minSdkVersion 24
+    targetSdkVersion getExtOrIntegerDefault('targetSdkVersion', 34)
     versionCode 1
     versionName "1.0"
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-override-color-scheme",
-  "version": "2.0.0",
+  "version": "1.0.3",
   "description": "React Native package to let users override the app's color scheme/theme",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-override-color-scheme",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "React Native package to let users override the app's color scheme/theme",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-override-color-scheme",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "React Native package to let users override the app's color scheme/theme",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
### What Changed?
Updated `minSDKVersion` to 24 to make the package compatible with RN 0.76.0. 

### How were the changes tested?
Unfortunately I could not make the example app work. I tried deleting the existing example and creating a new one but the level of changes needed to make it work within a mono-repo were non-trivial.
So instead of testing the changes using the example app, I referenced them locally within the Plum Village app to make sure the consuming app does not see the minSDKVersion related issues anymore.